### PR TITLE
Revert "chore(deps): update helm release loki to v6.35.1"

### DIFF
--- a/k8s/apps/loki/helm.jsonnet
+++ b/k8s/apps/loki/helm.jsonnet
@@ -3,6 +3,6 @@
   namespace: (import 'app.json5').namespace,
   chart: 'loki',
   repoURL: 'https://grafana.github.io/helm-charts',
-  targetRevision: '6.35.1',
+  targetRevision: '6.34.0',
   values: (importstr 'values.yaml'),
 }


### PR DESCRIPTION
Reverts walnuts1018/infra#2363

due to https://github.com/grafana/loki/issues/18784